### PR TITLE
Fix for 'branch' command to ensure only the first branch is reported

### DIFF
--- a/greasy.zsh
+++ b/greasy.zsh
@@ -83,7 +83,7 @@ function PA() {
 }
 
 # Returns the current branch for short commands like `git push origin $(branch) -f`.
-alias branch="git branch | grep '*' | sed 's/* \(.*\)$/\1/'"
+alias branch="git branch | grep '*' | sed 's/* \(.*\)$/\1/' | head -n 1"
 # Shows all git branches (works best with depot_tools).
 alias map="(git status 1&> /dev/null 2&>/dev/null && (git map-branches -v || git branch -vv)) || ls"
 alias continue="git rebase --continue || git merge --continue"


### PR DESCRIPTION
Fixes bug where 'branch' reported multiple branch names if multiple branches are checked out.