### PR TITLE
Add alias to index all authors in a repo

### DIFF
--- a/greasy.zsh
+++ b/greasy.zsh
@@ -97,6 +97,8 @@ alias gl="git ls-files | grep" # files
 function ge() {
   grep "[/\\\.]" | sed "s/.*-> //" | sed "s/:.*//" | sed "s/ *|.*//" | sort | uniq | xargs "$EDITOR"
 }
+# List authors
+alias ga="git ls-files | while read f; do git blame --line-porcelain \"$f\" | grep \"^author \" | sed \"s/author //\"; done | sort -f | uniq -ic | sort -n"
 # Single letter shortenings for extremely common git commands
 alias s="git status -sb 2> /dev/null"
 alias a="git add"


### PR DESCRIPTION
Adds alias for listing git commit authors (by number of lines committed to get a feel for best contacts in unfamiliar repos).

Counts lines by 'last touched' not who actually wrote the line, e.g. committing auto-formatting and file renames throws off line counts.